### PR TITLE
Notebook header

### DIFF
--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -21,6 +21,7 @@ but add new styling. */
 
 .cell .cell_input::before {
   content: "In";
+  font-weight: var(--pst-font-weight-caption);
 
   /* Left-aligns the text in this box and the one that follows it */
   padding-left: var(--pywt-code-block-padding);
@@ -48,6 +49,8 @@ div.cell div.cell_input {
 .pywt-handcoded-cell-output::before {
   content: "Out";
   display: block;
+  font-weight: var(--pst-font-weight-caption);
+  border-bottom: var(--mystnb-source-border-width) solid var(--pst-color-border);
 
   /* Left-aligns the text in this box and the one that follows it */
   padding-left: var(--pywt-code-block-padding);

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -7,75 +7,73 @@ In some cases these rules override MyST-NB. In some cases they override PyData
 Sphinx Theme or Sphinx. And in some cases they do not override existing styling
 but add new styling. */
 
-div.cell div.cell_input::before {
-  content: "In";
+/* Set up a few variables for this stylesheet */
+.cell,
+.pywt-handcoded-cell-output {
+  --pywt-cell-input-border-left-width: .2rem;
 
-  background-color: var(--pst-color-background);
+  /* This matches the padding applied to <pre> elements by PyData Sphinx Theme */
+  --pywt-code-block-padding: 1rem;
 
-  border-top-left-radius: var(--mystnb-source-border-radius);
-  border-top-right-radius: var(--mystnb-source-border-radius);
-
-  /* Left-align with the code below.
-     This is the same padding applied <pre> by PyData Sphinx Theme */
-  padding-left: 1rem;
+  /* override mystnb */
+  --mystnb-source-border-radius: .25rem; /* match PyData Sphinx Theme */
 }
 
+.cell .cell_input::before {
+  content: "In";
+
+  /* Left-aligns the text in this box and the one that follows it */
+  padding-left: var(--pywt-code-block-padding);
+}
+
+/* Cannot use `.cell .cell_input` selector because the stylesheet from MyST-NB
+   uses `div.cell div.cell_input` and we want to override those rules */
 div.cell div.cell_input {
   background-color: inherit;
   border-color: var(--pst-color-border);
-  border-left-width: 0.2rem;
+  border-left-width: var(--pywt-cell-input-border-left-width);
+  background-clip: padding-box;
+  overflow: hidden;
 }
 
-div.cell div.cell_output::before,
-div.pywt-handcoded-cell-output::before {
-  content: "Out";
+.cell .cell_output,
+.pywt-handcoded-cell-output {
+  border: var(--mystnb-source-border-width) solid var(--pst-color-surface);
+  border-radius: var(--mystnb-source-border-radius);
+  background-clip: padding-box;
+  overflow: hidden;
+}
 
+.cell .cell_output::before,
+.pywt-handcoded-cell-output::before {
+  content: "Out";
   display: block;
 
-  border: thin solid var(--pst-color-surface);
-  border-bottom: none;
-  border-top-left-radius: var(--mystnb-source-border-radius);
-  border-top-right-radius: var(--mystnb-source-border-radius);
-
-  /* Left-align with the code below.
-     This is the same padding applied <pre> by PyData Sphinx Theme */
-  padding-left: 1rem;
+  /* Left-aligns the text in this box and the one that follows it */
+  padding-left: var(--pywt-code-block-padding);
 }
 
-div.cell div.cell_output {
-  border-radius: 0;
-
-  /* Left-align the text in the output with the text in the input.
-     This value equals the border-left-width of the input cell */
-  margin-left: 0.2rem;
-}
-
-div.cell div.cell_output div.output,
-div.pywt-handcoded-cell-output {
+.cell .cell_output .output {
   background-color: inherit;
-
-  border-color: var(--pst-color-surface);
-
-  border-radius: var(--mystnb-source-border-radius);
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-
+  border: none;
   margin-top: 0;
 }
 
-div.cell div[class*=highlight-],
-div.cell div.highlight,
+.cell .cell_output,
+/* must prefix the following selector with `div.` to override Sphinx margin rule on div[class*=highlight-] */
 div.pywt-handcoded-cell-output {
-  border-radius: var(--mystnb-source-border-radius);
+  /* Left-align the text in the output with the text in the input */
+  margin-left: calc(var(--pywt-cell-input-border-left-width) - var(--mystnb-source-border-width));
 }
 
-div.cell div.cell_input pre,
-div.cell div.cell_output pre {
-  border-radius: var(--mystnb-source-border-radius);
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+.cell .cell_output .output,
+.cell .cell_input pre,
+.cell .cell_output pre,
+.pywt-handcoded-cell-output .highlight,
+.pywt-handcoded-cell-output pre {
+  border-radius: 0;
 }
 
-div.pywt-handcoded-cell-output pre {
-  border: none;
+.pywt-handcoded-cell-output pre {
+  border: none; /* MyST-NB sets border to none for <pre> tags inside div.cell */
 }

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -17,42 +17,41 @@ div.cell div.cell_input {
 /*
 Undo border radius on code cells (this styling actually comes from Sphinx, not MyST-NB)
 */
-
-div.cell pre {
-  border-radius: 0;
-}
-div.cell div.highlight {
+div.cell pre,
+div.cell div.highlight,
+div.pywt-handcoded-cell-output,
+div.pywt-handcoded-cell-output pre,
+div.pywt-handcoded-cell-output div.highlight {
   border-radius: 0;
 }
 
 /*
 Add border to output container, remove background color.
 */
-div.cell div.cell_output div.output {
+div.cell div.cell_output,
+div.pywt-handcoded-cell-output {
   background-color: var(--pst-color-background);
   border-radius: 0;
   border-color: var(--pst-color-border-muted);
+  border-style: solid;
+  border-width: 1px;
   border-top-style: double;
   border-top-width: medium;
 }
-
-/*
-By default, all code cells have a muted background.
-This removes that background.
-
-By adding a border above and removing the background color here,
-we create outputs that look outlined.
-*/
-div.cell div.cell_output pre {
+div.cell div.cell_output div.output,
+div.cell div.cell_output pre,
+div.pywt-handcoded-cell-output pre {
   background-color: transparent;
+  border: none;
 }
 
 /*
 Remove extra whitespace
 */
-div.cell div.cell_output {
-  margin-top: 0;
-}
+div.cell div.cell_output,
 div.cell div.cell_output > :first-child {
   margin-top: 0;
+}
+div.pywt-handcoded-cell-output {
+  margin-top: -1em;
 }

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -15,13 +15,15 @@ div.cell div.cell_input::before {
   border-top-left-radius: var(--mystnb-source-border-radius);
   border-top-right-radius: var(--mystnb-source-border-radius);
 
-  /* align with code below, this is the same padding applied <pre> by PyData Sphinx Theme */
+  /* Left-align with the code below.
+     This is the same padding applied <pre> by PyData Sphinx Theme */
   padding-left: 1rem;
 }
 
 div.cell div.cell_input {
   background-color: inherit;
   border-color: var(--pst-color-border);
+  border-left-width: 0.2rem;
 }
 
 div.cell div.cell_output::before,
@@ -35,12 +37,17 @@ div.pywt-handcoded-cell-output::before {
   border-top-left-radius: var(--mystnb-source-border-radius);
   border-top-right-radius: var(--mystnb-source-border-radius);
 
-  /* align with code below, this is the same padding applied <pre> by PyData Sphinx Theme */
+  /* Left-align with the code below.
+     This is the same padding applied <pre> by PyData Sphinx Theme */
   padding-left: 1rem;
 }
 
 div.cell div.cell_output {
   border-radius: 0;
+
+  /* Left-align the text in the output with the text in the input.
+     This value equals the border-left-width of the input cell */
+  margin-left: 0.2rem;
 }
 
 div.cell div.cell_output div.output,

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -46,12 +46,15 @@ div.pywt-handcoded-cell-output pre {
 }
 
 /*
-Remove extra whitespace
+Bring output up against input (remove extra whitespace)
 */
 div.cell div.cell_output,
 div.cell div.cell_output > :first-child {
   margin-top: 0;
 }
-div.pywt-handcoded-cell-output {
-  margin-top: -1em;
+div.cell:has(+ div.pywt-handcoded-cell-output) {
+  margin-bottom: 0;
+}
+div.cell + div.pywt-handcoded-cell-output {
+  margin-top: 0;
 }

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -8,13 +8,15 @@ Sphinx Theme or Sphinx. And in some cases they do not override existing styling
 but add new styling. */
 
 div.cell div.cell_input::before {
-  content: "\00A0In:";
-  font-weight: 600;
+  content: "In";
 
   background-color: var(--pst-color-background);
 
   border-top-left-radius: var(--mystnb-source-border-radius);
   border-top-right-radius: var(--mystnb-source-border-radius);
+
+  /* align with code below, this is the same padding applied <pre> by PyData Sphinx Theme */
+  padding-left: 1rem;
 }
 
 div.cell div.cell_input {
@@ -24,8 +26,7 @@ div.cell div.cell_input {
 
 div.cell div.cell_output::before,
 div.pywt-handcoded-cell-output::before {
-  content: "\00A0Out:";
-  font-weight: 600;
+  content: "Out";
 
   display: block;
 
@@ -33,6 +34,9 @@ div.pywt-handcoded-cell-output::before {
   border-bottom: none;
   border-top-left-radius: var(--mystnb-source-border-radius);
   border-top-right-radius: var(--mystnb-source-border-radius);
+
+  /* align with code below, this is the same padding applied <pre> by PyData Sphinx Theme */
+  padding-left: 1rem;
 }
 
 div.cell div.cell_output {

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -1,0 +1,58 @@
+/* MyST-NB
+
+This stylesheet targets elements output by MyST-NB that represent notebook
+cells.
+
+In some cases these rules override MyST-NB. In some cases they override PyData
+Sphinx Theme or Sphinx. And in some cases they do not override existing styling
+but add new styling. */
+
+/*
+Undo the border that MyST-NB puts on the input cell
+*/
+div.cell div.cell_input {
+  border: none;
+}
+
+/*
+Undo border radius on code cells (this styling actually comes from Sphinx, not MyST-NB)
+*/
+
+div.cell pre {
+  border-radius: 0;
+}
+div.cell div.highlight {
+  border-radius: 0;
+}
+
+/*
+Add border to output container, remove background color.
+*/
+div.cell div.cell_output div.output {
+  background-color: var(--pst-color-background);
+  border-radius: 0;
+  border-color: var(--pst-color-border-muted);
+  border-top-style: double;
+  border-top-width: medium;
+}
+
+/*
+By default, all code cells have a muted background.
+This removes that background.
+
+By adding a border above and removing the background color here,
+we create outputs that look outlined.
+*/
+div.cell div.cell_output pre {
+  background-color: transparent;
+}
+
+/*
+Remove extra whitespace
+*/
+div.cell div.cell_output {
+  margin-top: 0;
+}
+div.cell div.cell_output > :first-child {
+  margin-top: 0;
+}

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -21,6 +21,7 @@ but add new styling. */
 
 .cell .cell_input::before {
   content: "In";
+  border-bottom: var(--mystnb-source-border-width) solid var(--pst-color-border);
   font-weight: var(--pst-font-weight-caption);
 
   /* Left-aligns the text in this box and the one that follows it */
@@ -50,7 +51,6 @@ div.cell div.cell_input {
   content: "Out";
   display: block;
   font-weight: var(--pst-font-weight-caption);
-  border-bottom: var(--mystnb-source-border-width) solid var(--pst-color-border);
 
   /* Left-aligns the text in this box and the one that follows it */
   padding-left: var(--pywt-code-block-padding);

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -18,7 +18,8 @@ div.cell div.cell_input::before {
 }
 
 div.cell div.cell_input {
-  border-left-color: var(--pst-color-border);
+  background-color: inherit;
+  border-color: var(--pst-color-border);
 }
 
 div.cell div.cell_output::before,
@@ -40,6 +41,8 @@ div.cell div.cell_output {
 
 div.cell div.cell_output div.output,
 div.pywt-handcoded-cell-output {
+  background-color: inherit;
+
   border-color: var(--pst-color-surface);
 
   border-radius: var(--mystnb-source-border-radius);

--- a/doc/source/_static/myst-nb.css
+++ b/doc/source/_static/myst-nb.css
@@ -7,54 +7,61 @@ In some cases these rules override MyST-NB. In some cases they override PyData
 Sphinx Theme or Sphinx. And in some cases they do not override existing styling
 but add new styling. */
 
-/*
-Undo the border that MyST-NB puts on the input cell
-*/
-div.cell div.cell_input {
-  border: none;
-}
+div.cell div.cell_input::before {
+  content: "\00A0In:";
+  font-weight: 600;
 
-/*
-Undo border radius on code cells (this styling actually comes from Sphinx, not MyST-NB)
-*/
-div.cell pre,
-div.cell div.highlight,
-div.pywt-handcoded-cell-output,
-div.pywt-handcoded-cell-output pre,
-div.pywt-handcoded-cell-output div.highlight {
-  border-radius: 0;
-}
-
-/*
-Add border to output container, remove background color.
-*/
-div.cell div.cell_output,
-div.pywt-handcoded-cell-output {
   background-color: var(--pst-color-background);
-  border-radius: 0;
-  border-color: var(--pst-color-border-muted);
-  border-style: solid;
-  border-width: 1px;
-  border-top-style: double;
-  border-top-width: medium;
-}
-div.cell div.cell_output div.output,
-div.cell div.cell_output pre,
-div.pywt-handcoded-cell-output pre {
-  background-color: transparent;
-  border: none;
+
+  border-top-left-radius: var(--mystnb-source-border-radius);
+  border-top-right-radius: var(--mystnb-source-border-radius);
 }
 
-/*
-Bring output up against input (remove extra whitespace)
-*/
-div.cell div.cell_output,
-div.cell div.cell_output > :first-child {
+div.cell div.cell_input {
+  border-left-color: var(--pst-color-border);
+}
+
+div.cell div.cell_output::before,
+div.pywt-handcoded-cell-output::before {
+  content: "\00A0Out:";
+  font-weight: 600;
+
+  display: block;
+
+  border: thin solid var(--pst-color-surface);
+  border-bottom: none;
+  border-top-left-radius: var(--mystnb-source-border-radius);
+  border-top-right-radius: var(--mystnb-source-border-radius);
+}
+
+div.cell div.cell_output {
+  border-radius: 0;
+}
+
+div.cell div.cell_output div.output,
+div.pywt-handcoded-cell-output {
+  border-color: var(--pst-color-surface);
+
+  border-radius: var(--mystnb-source-border-radius);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+
   margin-top: 0;
 }
-div.cell:has(+ div.pywt-handcoded-cell-output) {
-  margin-bottom: 0;
+
+div.cell div[class*=highlight-],
+div.cell div.highlight,
+div.pywt-handcoded-cell-output {
+  border-radius: var(--mystnb-source-border-radius);
 }
-div.cell + div.pywt-handcoded-cell-output {
-  margin-top: 0;
+
+div.cell div.cell_input pre,
+div.cell div.cell_output pre {
+  border-radius: var(--mystnb-source-border-radius);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+div.pywt-handcoded-cell-output pre {
+  border: none;
 }

--- a/doc/source/_static/pywavelets.css
+++ b/doc/source/_static/pywavelets.css
@@ -1,27 +1,42 @@
 /* Custom CSS rules for the interactive documentation button */
 
 .try_examples_button {
-    color: white;
-    background-color: #0054a6;
-    border: none;
-    padding: 5px 10px;
-    border-radius: 10px;
-    margin-bottom: 5px;
-    box-shadow: 0 2px 5px rgba(108,108,108,0.2);
-    font-weight: bold;
-    font-size: small;
+  color: white;
+  background-color: #0054a6;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 10px;
+  margin-bottom: 5px;
+  box-shadow: 0 2px 5px rgba(108,108,108,0.2);
+  font-weight: bold;
+  font-size: small;
 }
 
 .try_examples_button:hover {
-background-color: #0066cc;
-transform: scale(1.02);
-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-cursor: pointer;
+  background-color: #0066cc;
+  transform: scale(1.02);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
 }
 
 .try_examples_button_container {
-    display: flex;
-    justify-content: flex-start;
-    gap: 10px;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+/*
+Admonitions on this site are styled with some top margin. This makes sense when
+the admonition appears within the flow of the article. But when it is the very
+first child of an article, its top margin gets added to the article's top
+padding, resulting in too much whitespace.
+
+We use "tip" admonitions at the top of each doc in the regression/ directory.
+This rule removes the top margin for tip admonitions when they occur as the very
+first child of some container. This will not affect non-first-child tip
+admonitions.
+*/
+.admonition.tip:first-child {
+  margin-top: 0;
 }

--- a/doc/source/_static/pywavelets.css
+++ b/doc/source/_static/pywavelets.css
@@ -31,12 +31,7 @@ Admonitions on this site are styled with some top margin. This makes sense when
 the admonition appears within the flow of the article. But when it is the very
 first child of an article, its top margin gets added to the article's top
 padding, resulting in too much whitespace.
-
-We use "tip" admonitions at the top of each doc in the regression/ directory.
-This rule removes the top margin for tip admonitions when they occur as the very
-first child of some container. This will not affect non-first-child tip
-admonitions.
 */
-.admonition.tip:first-child {
+.admonition.pywt-margin-top-0 {
   margin-top: 0;
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -269,6 +269,7 @@ html_static_path = ['_static']
 # _static directory.
 html_css_files = [
     "pywavelets.css",
+    "myst-nb.css"
 ]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,7 +39,7 @@ def preprocess_notebooks(app: Sphinx, *args, **kwargs):
 
     print("Converting Markdown files to IPyNB...")
     for path in (HERE / "regression").glob("*.md"):
-        if path.match("regression/header.md"):
+        if any(path.match(pattern) for pattern in exclude_patterns):
             continue
         nb = jupytext.read(str(path))
 
@@ -358,6 +358,7 @@ latex_documents = [
 exclude_patterns = [
     'substitutions.rst',
     'regression/header.md',
+    'regression/README.md',
     'regression/*.ipynb'  # exclude IPyNB files from the build
 ]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -400,13 +400,12 @@ strip_tagged_cells = True
 
 os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
+# https://myst-nb.readthedocs.io/en/latest/configuration.html
 nb_execution_mode = 'auto'
 nb_execution_timeout = 60
 nb_execution_allow_errors = False
-
+nb_execution_raise_on_error = True
 nb_render_markdown_format = "myst"
-render_markdown_format = "myst"
-
 nb_remove_code_source = False
 nb_remove_code_outputs = False
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,7 +43,7 @@ def preprocess_notebooks(app: Sphinx, *args, **kwargs):
             continue
         nb = jupytext.read(str(path))
 
-        # In .md to .ipynd conversion, do not include any cells that have the
+        # In .md to .ipynb conversion, do not include any cells that have the
         # jupyterlite_sphinx_strip tag
         nb.cells = [
             cell for cell in nb.cells if "jupyterlite_sphinx_strip" not in cell.metadata.get("tags", [])

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,6 +42,13 @@ def preprocess_notebooks(app: Sphinx, *args, **kwargs):
         if path.match("regression/header.md"):
             continue
         nb = jupytext.read(str(path))
+
+        # In .md to .ipynd conversion, do not include any cells that have the
+        # jupyterlite_sphinx_strip tag
+        nb.cells = [
+            cell for cell in nb.cells if "jupyterlite_sphinx_strip" not in cell.metadata.get("tags", [])
+        ]
+
         ipynb_path = path.with_suffix(".ipynb")
         with open(ipynb_path, "w") as f:
             nbformat.write(nb, f)

--- a/doc/source/regression/README.md
+++ b/doc/source/regression/README.md
@@ -52,5 +52,3 @@ Example markdown:
     ...
     ZeroDivisionError: division by zero
     ```
-
-    +++

--- a/doc/source/regression/README.md
+++ b/doc/source/regression/README.md
@@ -1,0 +1,56 @@
+# Regression folder
+
+This folder contains various useful examples illustrating how to use and how not
+to use PyWavelets.
+
+The examples are written in the [MyST markdown notebook
+format](https://myst-nb.readthedocs.io/en/v0.13.2/use/markdown.html). This
+allows each .md file to function simultaneously as documentation that can be fed
+into Sphinx and as a source file that can be converted to the Jupyter notebook
+format (.ipynb), which can then be opened in notebook applications such as
+JupyterLab. For this reason, each example page in this folder includes a header template
+that adds a blurb to the top of each page about how the page can be
+run or downloaded as a Jupyter notebook.
+
+There a few shortcomings to this approach of generating the code cell outputs in
+the documentation pages at build time rather than hand editing them into the
+document source file. One is that we can no longer compare the generated outputs
+with the expected outputs as we used to do with doctest. Another is that we
+lose some control over how we want the outputs to appear, unless we use a workaround.
+
+Here is the workaround we created. First we tell MyST-NB to remove the generated
+cell output from the documentation page by adding the `remove-output` tag to the
+`code-cell` directive in the markdown file. Then we hand code the output in a
+`code-block` directive, not to be confused with `code-cell`! The `code-cell`
+directive says "I am notebook code cell input, run me!" The `code-block`
+directive says, "I am just a block of code for documentation purposes, don't run
+me!" To the code block, we add the `.pywt-handcoded-cell-output` class so that
+we can style it to look the same as other cell outputs on the same HTML page.
+Finally, we tag the handcoded output with `jupyterlite_sphinx_strip` so that we
+can exclude it when converting from .md to .ipynb. That way only generated
+output appears in the .ipynb notebook.
+
+To recap:
+
+- We use the `remove-output` tag to remove the **generated** code cell output
+during .md to .html conversion (this conversion is done by MyST-NB).
+- We use the `jupyterlite_sphinx_strip` tag to remove the **handcoded** output
+during .md to .ipynb conversion (this conversion is done by Jupytext).
+
+Example markdown:
+
+    ```{code-cell}
+    :tags: [raises-exception, remove-output]
+    1 / 0
+    ```
+
+    +++ {"tags" ["jupyterlite_sphinx_strip"]}
+
+    ```{code-block} python
+    :class: pywt-handcoded-cell-output
+    Traceback (most recent call last):
+    ...
+    ZeroDivisionError: division by zero
+    ```
+
+    +++

--- a/doc/source/regression/dwt-idwt.md
+++ b/doc/source/regression/dwt-idwt.md
@@ -16,25 +16,7 @@ mystnb:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: dwt-idwt.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <dwt-idwt.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <dwt-idwt.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/dwt-idwt.md
+++ b/doc/source/regression/dwt-idwt.md
@@ -154,10 +154,21 @@ Remember that only one argument at a time can be `None`:
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(pywt.idwt(None, None, 'db2', 'symmetric'))
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: At least one coefficient parameter must be specified.
+```
+
++++
 
 ### Coefficients data size in `pywt.idwt`
 
@@ -166,10 +177,21 @@ must have the same size.
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(pywt.idwt([1, 2, 3, 4, 5], [1, 2, 3, 4], 'db2', 'symmetric'))
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: Coefficients arrays must have the same size.
+```
+
++++
 
 Not every coefficient array can be used in `idwt`. In the
 following example the `idwt` will fail because the input arrays are
@@ -179,10 +201,21 @@ mode is `4`, not `3`:
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 pywt.idwt([1,2,4], [4,1,3], 'db4', 'symmetric')
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: Invalid coefficient arrays length for specified wavelet. Wavelet and mode must be the same as used for decomposition.
+```
+
++++
 
 ```{code-cell}
 int(pywt.dwt_coeff_len(1, pywt.Wavelet('db4').dec_len, 'symmetric'))

--- a/doc/source/regression/dwt-idwt.md
+++ b/doc/source/regression/dwt-idwt.md
@@ -9,9 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-mystnb:
-  execution_allow_errors: true
-  execution_show_tb: true
 ---
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}

--- a/doc/source/regression/dwt-idwt.md
+++ b/doc/source/regression/dwt-idwt.md
@@ -16,13 +16,11 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # DWT and IDWT
 
 ## Discrete Wavelet Transform
 
-Let's do a Discrete Wavelet Transform of some sample data `x`
+Let's do a [Discrete Wavelet Transform](ref-dwt) of some sample data `x`
 using the `db2` wavelet. It's simple:
 
 ```{code-cell}
@@ -44,7 +42,7 @@ cD
 
 ## Inverse Discrete Wavelet Transform
 
-Now, let's do the opposite operation: an Inverse Discrete Wavelet Transform:
+Now let's do the opposite operation, an [Inverse Discrete Wavelet Transform](ref-idwt):
 
 ```{code-cell}
 pywt.idwt(cA, cD, 'db2')
@@ -54,7 +52,7 @@ Voilà! That's it!
 
 ## More examples
 
-Now, let's experiment with `dwt` some more. For example, let's pass a
+Now let's experiment with `dwt()` some more. For example, let's pass a
 `Wavelet` object instead of the wavelet name and specify the signal
 extension mode (the default is `Modes.symmetric`) for the border effect
 handling:
@@ -76,7 +74,7 @@ Note that the output coefficients arrays' length depends not only on the
 input data length but also on the `Wavelet` type (particularly on its
 filters length `Wavelet.dec_len` that are used in the transformation).
 
-To find out what the size of the output data will be, use the `dwt_coeff_len`
+To find out what the size of the output data will be, use the `dwt_coeff_len()`
 function:
 
 ```{code-cell}
@@ -97,7 +95,7 @@ Looks fine. (And if you expected that the output length would be a half of the
 input data length, well, that's the trade-off that allows for the perfect
 reconstruction...).
 
-The third argument of the `dwt_coeff_len` function is the already mentioned signal
+The third argument of the `dwt_coeff_len()` function is the already mentioned signal
 extension mode (please refer to the PyWavelets' documentation for the `modes`
 description). Currently, there are six extension modes available under `Modes`:
 
@@ -165,8 +163,6 @@ Traceback (most recent call last):
 ValueError: At least one coefficient parameter must be specified.
 ```
 
-+++
-
 ### Coefficients data size in `pywt.idwt`
 
 When doing the `idwt` transform, usually the coefficient arrays
@@ -187,8 +183,6 @@ Traceback (most recent call last):
 ...
 ValueError: Coefficients arrays must have the same size.
 ```
-
-+++
 
 Not every coefficient array can be used in `idwt`. In the
 following example the `idwt` will fail because the input arrays are
@@ -211,8 +205,6 @@ Traceback (most recent call last):
 ...
 ValueError: Invalid coefficient arrays length for specified wavelet. Wavelet and mode must be the same as used for decomposition.
 ```
-
-+++
 
 ```{code-cell}
 int(pywt.dwt_coeff_len(1, pywt.Wavelet('db4').dec_len, 'symmetric'))

--- a/doc/source/regression/gotchas.md
+++ b/doc/source/regression/gotchas.md
@@ -16,8 +16,6 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # Gotchas
 
 PyWavelets utilizes `NumPy` under the hood. That's why handling the data

--- a/doc/source/regression/gotchas.md
+++ b/doc/source/regression/gotchas.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: gotchas.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <gotchas.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <gotchas.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/header.md
+++ b/doc/source/regression/header.md
@@ -4,7 +4,7 @@
 This page can also be run or downloaded as a Jupyter notebook.
 
 - Run in a new tab using JupyterLite[^what-is-lite]:
-  ```{jupyterlite} {{ parent_docname }}.ipynb
+  ```{notebooklite} {{ parent_docname }}.ipynb
   :new_tab: True
   ```
 - Download:

--- a/doc/source/regression/header.md
+++ b/doc/source/regression/header.md
@@ -1,0 +1,13 @@
+````{tip}
+
+This page can also be run or downloaded as a notebook.
+
+```{jupyterlite} {{ parent_docname }}.ipynb
+:new_tab: True
+```
+
+Downloads:
+
+1. {download}`Download {{ parent_docname }}.ipynb <{{ parent_docname }}.ipynb>`
+2. {download}`Download {{ parent_docname }}.md <{{ parent_docname }}.md>`
+````

--- a/doc/source/regression/header.md
+++ b/doc/source/regression/header.md
@@ -1,13 +1,15 @@
 ````{tip}
+:class: pywt-margin-top-0
 
-This page can also be run or downloaded as a notebook.
+This page can also be run or downloaded as a Jupyter notebook.
 
-```{jupyterlite} {{ parent_docname }}.ipynb
-:new_tab: True
-```
+- Run in a new tab using JupyterLite[^what-is-lite]:
+  ```{jupyterlite} {{ parent_docname }}.ipynb
+  :new_tab: True
+  ```
+- Download:
+  - Jupyter notebook: {download}`{{ parent_docname }}.ipynb <{{ parent_docname }}.ipynb>`
+  - MyST markdown: {download}`{{ parent_docname }}.md <{{ parent_docname }}.md>`
 
-Downloads:
-
-1. {download}`Download {{ parent_docname }}.ipynb <{{ parent_docname }}.ipynb>`
-2. {download}`Download {{ parent_docname }}.md <{{ parent_docname }}.md>`
+[^what-is-lite]: [JupyterLite](https://jupyterlite.readthedocs.io) is a distribution of JupyterLab that runs entirely within a web browser. All computations run in the browser; none are sent to a server.
 ````

--- a/doc/source/regression/index.rst
+++ b/doc/source/regression/index.rst
@@ -5,9 +5,8 @@
 Usage examples
 ==============
 
-The following examples are used as doctest regression tests written using reST
-markup. They are included in the documentation since they contain various useful
-examples illustrating how to use and how not to use PyWavelets.
+The following pages contain various useful examples illustrating how to use and
+how not to use PyWavelets.
 
 For more usage examples see the `demo`_ directory in the source package.
 

--- a/doc/source/regression/modes.md
+++ b/doc/source/regression/modes.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: modes.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <modes.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <modes.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/modes.md
+++ b/doc/source/regression/modes.md
@@ -16,11 +16,9 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # Signal Extension Modes
 
-Let's import `pywt`, first:
+Import `pywt` first:
 
 ```{code-cell}
 import pywt
@@ -39,13 +37,13 @@ def format_array(a):
     return numpy.array2string(a, precision=5, separator=' ', suppress_small=True)
 ```
 
-A list of available signal extension modes (`Modes`) is provided as follows:
+A list of available signal extension [modes](Modes):
 
 ```{code-cell}
 pywt.Modes.modes
 ```
 
-Therefore, an invalid mode name should raise a `ValueError`:
+An invalid mode name should raise a `ValueError`:
 
 ```{code-cell}
 ---
@@ -71,7 +69,7 @@ for mode_name in ['zero', 'constant', 'symmetric', 'reflect', 'periodic', 'smoot
     print("Mode: %d (%s)" % (mode, mode_name))
 ```
 
-The default mode is symmetric, i.e., `Modes.symmetric`:
+The default mode is [symmetric](Modes.symmetric):
 
 ```{code-cell}
 cA, cD = pywt.dwt(x, 'db2')
@@ -86,13 +84,10 @@ cD
 pywt.idwt(cA, cD, 'db2')
 ```
 
-And using a keyword argument:
+Specify the mode using a keyword argument:
 
 ```{code-cell}
 cA, cD = pywt.dwt(x, 'db2', mode='symmetric')
-```
-
-```{code-cell}
 cA
 ```
 

--- a/doc/source/regression/modes.md
+++ b/doc/source/regression/modes.md
@@ -49,9 +49,16 @@ Therefore, an invalid mode name should raise a `ValueError`:
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 pywt.dwt([1,2,3,4], 'db2', 'invalid')
+```
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: Unknown mode name 'invalid'.
 ```
 
 You can also refer to modes via the attributes of the `Modes` class:

--- a/doc/source/regression/multilevel.md
+++ b/doc/source/regression/multilevel.md
@@ -16,8 +16,6 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # Multilevel DWT, IDWT and SWT
 
 ## Multilevel DWT decomposition

--- a/doc/source/regression/multilevel.md
+++ b/doc/source/regression/multilevel.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: multilevel.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <multilevel.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <multilevel.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/wavelet.md
+++ b/doc/source/regression/wavelet.md
@@ -16,8 +16,6 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # The Wavelet object
 
 ## Wavelet families and builtin Wavelets names
@@ -73,8 +71,8 @@ print(w)
 
 But the most important bits of information are the wavelet filters coefficients,
 which are used in Discrete Wavelet Transform. These coefficients
-can be obtained via the `Wavelet.dec_lo`, `Wavelet.dec_hi`, `Wavelet.rec_lo`,
-and the `~Wavelet.rec_hi` attributes, which
+can be obtained via the `Wavelet.dec_lo`, `dec_hi`, `rec_lo`,
+and the `rec_hi` attributes, which
 correspond to lowpass & highpass decomposition filters, and lowpass &
 highpass reconstruction filters respectively:
 
@@ -83,7 +81,7 @@ def print_array(arr):
     print("[%s]" % ", ".join(["%.14f" % x for x in arr]))
 ```
 
-Another way to get the filters data is to use the `Wavelet.filter_bank`
+Another way to get the filters data is to use the `filter_bank`
 attribute, which returns all four filters in a tuple:
 
 ```{code-cell}
@@ -92,7 +90,7 @@ w.filter_bank == (w.dec_lo, w.dec_hi, w.rec_lo, w.rec_hi)
 
 Other properties of a `Wavelet` object are:
 
-1. `Wavelet.name`, `Wavelet.short_family_name`, and `Wavelet.family_name`:
+`name`, `short_family_name`, and `family_name`:
 
 ```{code-cell}
 print(w.name)
@@ -100,7 +98,7 @@ print(w.short_family_name)
 print(w.family_name)
 ```
 
-2. Decomposition (`Wavelet.dec_len`) and reconstruction (`Wavelet.rec_len`) filter lengths:
+Decomposition (`dec_len`) and reconstruction (`rec_len`) filter lengths:
 
 ```{code-cell}
 w.dec_len
@@ -110,7 +108,7 @@ w.dec_len
 w.rec_len
 ```
 
-3. Orthogonality (`Wavelet.orthogonal`) and biorthogonality (`Wavelet.biorthogonal`):
+Orthogonality (`orthogonal`) and biorthogonality (`biorthogonal`):
 
 ```{code-cell}
 w.orthogonal
@@ -120,14 +118,14 @@ w.orthogonal
 w.biorthogonal
 ```
 
-3. Symmetry (`Wavelet.symmetry`):
+Symmetry (`symmetry`):
 
 ```{code-cell}
 print(w.symmetry)
 ```
 
-4. Number of vanishing moments for the scaling function `phi` (`Wavelet.vanishing_moments_phi`)
-   and the wavelet function `psi` (`Wavelet.vanishing_moments_psi`), associated with the filters:
+Number of vanishing moments for the scaling function `phi` (`vanishing_moments_phi`)
+and the wavelet function `psi` (`vanishing_moments_psi`), associated with the filters:
 
 ```{code-cell}
  w.vanishing_moments_phi
@@ -138,7 +136,7 @@ w.vanishing_moments_psi
 ```
 
 Now when we know a bit about the builtin Wavelets, let's see how to create
-custom `Wavelets` objects. These can be done in two ways:
+[custom wavelets](custom-wavelets). These can be created in two ways:
 
 1. Passing the filter bank object that implements the `filter_bank` attribute. The
    attribute must return four filters coefficients.
@@ -152,11 +150,7 @@ class MyHaarFilterBank(object):
           [sqrt(2)/2, sqrt(2)/2], [-sqrt(2)/2, sqrt(2)/2],
           [sqrt(2)/2, sqrt(2)/2], [sqrt(2)/2, -sqrt(2)/2]
         )
-```
 
-and let's put this in action:
-
-```{code-cell}
 my_wavelet = pywt.Wavelet('My Haar Wavelet', filter_bank=MyHaarFilterBank())
 ```
 
@@ -171,7 +165,7 @@ my_filter_bank = (
 my_wavelet = pywt.Wavelet('My Haar Wavelet', filter_bank=my_filter_bank)
 ```
 
-Note that such custom `Wavelets` objects **will not** have all the properties set
+Note that such custom wavelets **will not** have all the properties set
 to correct values and some of them could be missing:
 
 ```{code-cell}
@@ -197,7 +191,7 @@ We all know that the fun with wavelets is in wavelet functions.
 Now, what would this package be without a tool to compute wavelet
 and scaling functions approximations?
 
-This is the purpose of the `Wavelet.wavefun` method, which is used to
+This is the purpose of the `wavefun()` method, which is used to
 approximate scaling function (`phi`) and wavelet function (`psi`) at the
 given level of refinement, based on the filters coefficients.
 
@@ -230,7 +224,7 @@ w.orthogonal
 ```
 
 :::{seealso}
-You can find live examples of the usage of `Wavelet.wavefun` and
+You can find live examples of the usage of `wavefun()` and
 images of all the built-in wavelets on the
 [Wavelet Properties Browser](http://wavelets.pybytes.com) page.
 

--- a/doc/source/regression/wavelet.md
+++ b/doc/source/regression/wavelet.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: wavelet.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <wavelet.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <wavelet.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/wp.md
+++ b/doc/source/regression/wp.md
@@ -16,8 +16,6 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # Wavelet Packets
 
 ## `import pywt` and construct a helper function
@@ -26,7 +24,7 @@ kernelspec:
 import pywt
 ```
 
-This helper function that can format arrays in a consistent manner across
+This helper function can format arrays in a consistent manner across
 different systems. Please note that this function is just for the purpose of
 this example and is not part of the PyWavelets library, and it is not necessary
 or required to use it in your own code:
@@ -53,14 +51,12 @@ The input data and decomposition coefficients are stored in the
 
 ```{code-cell}
 print(wp.data)
-[1, 2, 3, 4, 5, 6, 7, 8]
 ```
 
-Nodes `Node` are identified by their paths, i.e., `Node.path`. For the root
+Nodes are identified by their paths, i.e., `Node.path`. For the root
 node, the path is `''` and the decomposition level is `0`.
 
 ```{code-cell}
-# Should return blank
 print(repr(wp.path))
 ```
 
@@ -90,9 +86,9 @@ First check what is the maximum level of decomposition:
 print(wp.maxlevel)
 ```
 
-and try accessing subnodes of the WP tree:
+and try accessing subnodes of the WP tree.
 
-- 1st level:
+1st level:
 
 ```{code-cell}
 print(wp['a'].data)
@@ -102,7 +98,7 @@ print(wp['a'].data)
 print(wp['a'].path)
 ```
 
-- 2nd level:
+2nd level:
 
 ```{code-cell}
 print(wp['aa'].data)
@@ -112,7 +108,7 @@ print(wp['aa'].data)
 print(wp['aa'].path)
 ```
 
-- 3rd level:
+3rd level:
 
 ```{code-cell}
 print(wp['aaa'].data)
@@ -140,9 +136,6 @@ Traceback (most recent call last):
 IndexError: Path length is out of range.
 ```
 
-+++
-
-
 Now, try an invalid path:
 
 ```{code-cell}
@@ -161,8 +154,6 @@ Traceback (most recent call last):
 ValueError: Subnode name must be in ['a', 'd'], not 'c'.
 ```
 
-+++
-
 which just yielded a `ValueError`.
 
 ### Accessing `Node`'s attributes
@@ -174,9 +165,9 @@ of the `Node` class (which in turn inherits from the `BaseNode` class).
 Tree nodes can be accessed using the `obj[x]` (`Node.__getitem__`)
 operator.
 
-Each tree node has a set of attributes: `Node.data`, `Node.path`,
-`Node.node_name`, `Node.parent`, `Node.level`,
-`Node.maxlevel` and `Node.mode`.
+Each tree node has a set of attributes: `data`, `path`,
+`node_name`, `parent`, `level`,
+`maxlevel` and `mode`.
 
 ```{code-cell}
 x = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -230,7 +221,7 @@ or sorted based on the band frequency (`freq`):
 print([node.path for node in wp.get_level(3, 'freq')])
 ```
 
-Note that `WaveletPacket.get_level` also performs automatic decomposition
+Note that `WaveletPacket.get_level()` also performs automatic decomposition
 until it reaches the specified `level`.
 
 ## Reconstructing data from Wavelet Packets
@@ -240,7 +231,7 @@ x = [1, 2, 3, 4, 5, 6, 7, 8]
 wp = pywt.WaveletPacket(data=x, wavelet='db1', mode='symmetric')
 ```
 
-Now, let's create a new instance of the `WaveletPacket` class and set its nodes
+Now create a new instance of the `WaveletPacket` class and set its nodes
 with some data.
 
 ```{code-cell}
@@ -362,7 +353,7 @@ x = [1, 2, 3, 4, 5, 6, 7, 8]
 wp = pywt.WaveletPacket(data=x, wavelet='db1', mode='symmetric')
 ```
 
-1. At first the wp's attribute `a` is `None`:
+At first the wp's attribute `a` is `None`:
 
 ```{code-cell}
 print(wp.a)
@@ -370,14 +361,14 @@ print(wp.a)
 
 **Remember that you should not rely on the attribute access.**
 
-2. At the first attempt to access the node, it is computed via the decomposition
-   of its parent node (which is the `wp` object itself).
+At the first attempt to access the node, it is computed via the decomposition
+of its parent node (which is the `wp` object itself).
 
 ```{code-cell}
 print(wp['a'])
 ```
 
-3. Now, `wp.a` is set to the newly created node:
+Now `wp.a` is set to the newly created node:
 
 ```{code-cell}
 print(wp.a)

--- a/doc/source/regression/wp.md
+++ b/doc/source/regression/wp.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: wp.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <wp.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <wp.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/wp.md
+++ b/doc/source/regression/wp.md
@@ -126,19 +126,42 @@ Oops, we have reached the maximum level of decomposition and received an `IndexE
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(wp['aaaa'].data)
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+IndexError: Path length is out of range.
+```
+
++++
+
 
 Now, try an invalid path:
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(wp['ac'])
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: Subnode name must be in ['a', 'd'], not 'c'.
+```
+
++++
 
 which just yielded a `ValueError`.
 

--- a/doc/source/regression/wp2d.md
+++ b/doc/source/regression/wp2d.md
@@ -13,25 +13,7 @@ kernelspec:
 
 +++ {"tags": ["jupyterlite_sphinx_strip"]}
 
-```{eval-rst}
-.. currentmodule:: pywt
-
-.. dropdown:: 🧑‍🔬 This notebook can be executed online. Click this section to try it out! ✨
-    :color: success
-
-    .. notebooklite:: wp2d.ipynb
-      :width: 100%
-      :height: 600px
-      :prompt: Open notebook
-
-.. dropdown:: Download this notebook
-    :color: info
-    :open:
-
-    Please use the following links to download this notebook in various formats:
-
-    1. :download:`Download IPyNB (IPython Notebook) <wp2d.ipynb>`
-    2. :download:`Download Markdown Notebook (Jupytext) <wp2d.md>`
+```{include} header.md
 ```
 
 +++

--- a/doc/source/regression/wp2d.md
+++ b/doc/source/regression/wp2d.md
@@ -147,10 +147,21 @@ print(wp['aaa'].data)
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(wp['aaaa'].data)
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+IndexError: Path length is out of range.
+```
+
++++
 
 Oops, we have reached the maximum level of decomposition for the `'aaaa'` path,
 which, by the way, was:
@@ -163,10 +174,21 @@ Now, try an invalid path:
 
 ```{code-cell}
 ---
-tags: [raises-exception]
+tags: [raises-exception, remove-output]
 ---
 print(wp['f'])
 ```
+
++++ {"tags": ["jupyterlite_sphinx_strip"]}
+
+```{code-block} python
+:class: pywt-handcoded-cell-output
+Traceback (most recent call last):
+...
+ValueError: Subnode name must be in ['a', 'h', 'v', 'd'], not 'f'.
+```
+
++++
 
 ### Accessing Node2D's attributes
 

--- a/doc/source/regression/wp2d.md
+++ b/doc/source/regression/wp2d.md
@@ -16,8 +16,6 @@ kernelspec:
 ```{include} header.md
 ```
 
-+++
-
 # 2D Wavelet Packets
 
 ## Import pywt
@@ -36,7 +34,7 @@ x = numpy.array([[1, 2, 3, 4, 5, 6, 7, 8]] * 8, 'd')
 print(x)
 ```
 
-Now create a 2D Wavelet Packet `pywt.WaveletPacket2D` object:
+Now create a 2D [Wavelet Packet](ref-wp) object:
 
 ```{code-cell}
 wp = pywt.WaveletPacket2D(data=x, wavelet='db1', mode='symmetric')
@@ -49,7 +47,7 @@ The input `data` and decomposition coefficients are stored in the
 print(wp.data)
 ```
 
-Nodes (the `Node2D>` class) are identified by paths. For the root node, the path is
+Nodes (the `Node2D` class) are identified by paths. For the root node, the path is
 `''` and the decomposition level is `0`.
 
 ```{code-cell}
@@ -161,8 +159,6 @@ Traceback (most recent call last):
 IndexError: Path length is out of range.
 ```
 
-+++
-
 Oops, we have reached the maximum level of decomposition for the `'aaaa'` path,
 which, by the way, was:
 
@@ -187,8 +183,6 @@ Traceback (most recent call last):
 ...
 ValueError: Subnode name must be in ['a', 'h', 'v', 'd'], not 'f'.
 ```
-
-+++
 
 ### Accessing Node2D's attributes
 
@@ -233,7 +227,7 @@ print(wp['av'].mode)
 We can get all nodes on the particular level using the
 `WaveletPacket2D.get_level` method:
 
-- 0 level - the root `wp` node:
+0 level - the root `wp` node:
 
 ```{code-cell}
 len(wp.get_level(0))
@@ -253,7 +247,7 @@ len(wp.get_level(1))
 print([node.path for node in wp.get_level(1)])
 ```
 
-- 2nd level of decomposition:
+2nd level of decomposition:
 
 ```{code-cell}
 len(wp.get_level(2))
@@ -268,7 +262,7 @@ for i, path in enumerate(paths):
         print(path, end=' ')
 ```
 
-- 3rd level of decomposition:
+3rd level of decomposition:
 
 ```{code-cell}
 print(len(wp.get_level(3)))
@@ -407,7 +401,7 @@ x = numpy.array([[1, 2, 3, 4, 5, 6, 7, 8]] * 8)
 wp = pywt.WaveletPacket2D(data=x, wavelet='db1', mode='symmetric')
 ```
 
-1. At first, the `wp`'s attribute `a` is `None`
+At first, the `wp`'s attribute `a` is `None`
 
 ```{code-cell}
 print(wp.a)
@@ -415,14 +409,14 @@ print(wp.a)
 
 **Remember that you should not rely on the attribute access.**
 
-2. During the first attempt to access the node it is computed
-   via decomposition of its parent node (the wp object itself).
+During the first attempt to access the node it is computed
+via decomposition of its parent node (the wp object itself).
 
 ```{code-cell}
 print(wp['a'])
 ```
 
-3. Now the `a` is set to the newly created node:
+Now the `a` is set to the newly created node:
 
 ```{code-cell}
 print(wp.a)

--- a/util/readthedocs/requirements.txt
+++ b/util/readthedocs/requirements.txt
@@ -1,6 +1,6 @@
 cython
 docutils
-jupyterlite-sphinx>=0.16.2
+jupyterlite-sphinx>=0.17.1
 jupyterlite-pyodide-kernel
 jupytext
 pydata-sphinx-theme


### PR DESCRIPTION
> [!NOTE]  
> This is a PR on top of a PR, https://github.com/PyWavelets/pywt/pull/741.

This PR includes the following changes to the "regression" docs (doc/source/regression):

- Header: Puts JupyterLite and download links above each doc
- Notebook cell styling: Restyles notebook cells that have been rendered to HTML with MyST-NB 
- Handcoded output: Introduces workaround to control how notebook cell outputs look in the rendered doc page (see doc/source/regression/README.md for detailed explanation)
- Corrections and edits: Make some changes to the text and reverts some changes that were made (see inline code comments)

### Header 

- Shared header file (regression/header.md)
- Each relevant doc file includes the shared header file via the `include` directive
- The header file contains substitutions for the parent document name (the document that includes the header) that look like `{{ parent_docname }}`
- These substitutions are replaced with the name of the parent document by a callback for the Sphinx "include-read" event

![screenshot](https://github.com/user-attachments/assets/5fb4f2c2-1d43-4c56-ba9a-770bb1f79a36)

### Notebook cell styling

I started with [Melissa's suggested style changes](https://github.com/PyWavelets/pywt/pull/741#issuecomment-2246154051), as shown in the following screenshot:

![](https://github.com/user-attachments/assets/7068163a-027e-40f3-bdc3-bb3456472544)

This design is good for accessibility because it labels the input cells with "In" and the output cells with "Out".

I made a few small tweaks to Melissa's design - changed the left border color, decreased the font weight, left-aligned the labels with the code, made the labels look more like the [code block captions](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/blocks.html#with-caption) in the PyData theme. Here's how it looks in light mode:

<img width="735" alt="" src="https://github.com/user-attachments/assets/8be3100d-c0b1-4633-ae83-7cbd88fd0ae9" />

Here's how it looks in dark mode:

<img width="735" alt="" src="https://github.com/user-attachments/assets/a3139b00-56b5-4cbf-a31e-c3610de4bc1a" />
